### PR TITLE
fix link to Ansible documenation on lookup plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 This is a lookup module for generic secrets in [Vault](https://vaultproject.io/)(the HashiCorp project).
 
 ### Installation
-lookup plugins can be loaded from several different locations similar to $PATH, see
-[http://docs.ansible.com/ansible/intro_configuration.html#lookup-plugins](docs).
+lookup plugins can be loaded from several different locations similar to $PATH, see [docs](http://docs.ansible.com/ansible/intro_configuration.html#lookup-plugins).
 
 ### Usage
 The address to the Vault server and the auth token are fetched from environment variables


### PR DESCRIPTION
Right now the link takes you to:
https://github.com/jhaals/ansible-vault/blob/master/docs

Which is a 404 and I think you got the [] and () mixed up in GitHub Flavored Markdown. Fixed?
