### PR TITLE
Added parameters to vault calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ ansible-vault then works as any other lookup plugin.
 
 # Generic secrets
 {{ lookup('vault', 'secret/hello').value }} # world
+# Generic secrets with parameters
+{{ lookup('vault', 'pki/issue/example-dot-com common_name=foo.example.com format=pem_bundle').certificate }}
 # Specify field inside lookup
 {{ lookup('vault', 'secret/hello', 'value') }} # world
 

--- a/vault.py
+++ b/vault.py
@@ -1,5 +1,4 @@
 import os
-import urllib
 import urllib2
 import json
 import sys


### PR DESCRIPTION
Enables to talk to parameterized secret backends like [https://www.vaultproject.io/docs/secrets/pki/](https://www.vaultproject.io/docs/secrets/pki/)
