### PR TITLE
fix ansible 1.9.x compatability code

### DIFF
--- a/vault.py
+++ b/vault.py
@@ -13,7 +13,9 @@ except ImportError:
     class LookupBase(object):
         def __init__(self, basedir=None, runner=None, **kwargs):
             self.runner = runner
-            self.basedir = self.runner.basedir
+            self.basedir = basedir or (self.runner.basedir
+                                       if self.runner
+                                       else None)
 
         def get_basedir(self, variables):
             return self.basedir


### PR DESCRIPTION
Previously, setting self.basedir would fail if runner was None
Since evaluating self.runner.basedir would fail with:
    AttributeError: 'NoneType' object has no attribute 'basedir'

In addition to providing support for this being None, also respect the setting
of self.basedir directly from basedir, as a higher precedence. Previously any
passed arg for basedir was ignored.
