### PR TITLE
Feature/old python

### DIFF
--- a/vault.py
+++ b/vault.py
@@ -2,6 +2,8 @@ import os
 import urllib2
 import json
 import ssl
+from distutils.version import StrictVersion
+from sys import version_info
 from urlparse import urljoin
 
 from ansible.errors import AnsibleError
@@ -63,15 +65,25 @@ class LookupModule(LookupBase):
         if not token:
             raise AnsibleError('VAULT_TOKEN environment variable is missing')
 
-        context = ssl.create_default_context(cafile=os.getenv('VAULT_CACERT'),
-                                             capath=os.getenv('VAULT_CAPATH'))
-
-        request_url = urljoin(url, "v1/%s" % (key))
         try:
+            context = ssl.create_default_context(cafile=os.getenv('VAULT_CACERT'),
+                                                 capath=os.getenv('VAULT_CAPATH'))
+            request_url = urljoin(url, "v1/%s" % (key))
             req = urllib2.Request(request_url, data)
             req.add_header('X-Vault-Token', token)
             req.add_header('Content-Type', 'application/json')
             response = urllib2.urlopen(req, context=context)
+        except AttributeError as e:
+            python_version_cur = ".".join([str(version_info.major),
+                                           str(version_info.minor),
+                                           str(version_info.micro)])
+            python_version_min = "2.7.9"
+            if StrictVersion(python_version_cur) < StrictVersion(python_version_min):
+                raise AnsibleError('Unable to read %s from vault:'
+                                   ' Using Python %s and vault lookup plugin requires at least %s'
+                                   % (key, python_version_cur, python_version_min))
+            else:
+                raise AnsibleError('Unable to read %s from vault: %s' % (key, e))
         except urllib2.HTTPError as e:
             raise AnsibleError('Unable to read %s from vault: %s' % (key, e))
         except Exception as e:

--- a/vault.py
+++ b/vault.py
@@ -13,7 +13,9 @@ except ImportError:
     class LookupBase(object):
         def __init__(self, basedir=None, runner=None, **kwargs):
             self.runner = runner
-            self.basedir = self.runner.basedir
+            self.basedir = basedir or (self.runner.basedir
+                                       if self.runner
+                                       else None)
 
         def get_basedir(self, variables):
             return self.basedir


### PR DESCRIPTION
This doesn't actually change any behavior if using python >= 2.7.9

It just makes the error clearer when using python < 2.7.9, which did not, and still does not, work. The offending method is ssl.create_default_context()

Note that the latest version of python2.7 for Ubuntu 14.04 LTS as of this writing is 2.7.6. pyenv is a fine workaround, but it helps to know what's actually going wrong.