### PR TITLE
Feature/dot vault token file

### DIFF
--- a/vault.py
+++ b/vault.py
@@ -2,6 +2,8 @@ import os
 import urllib2
 import json
 import ssl
+from distutils.version import StrictVersion
+from sys import version_info
 from urlparse import urljoin
 
 from ansible.errors import AnsibleError
@@ -63,15 +65,25 @@ class LookupModule(LookupBase):
         if not token:
             raise AnsibleError('VAULT_TOKEN environment variable is missing')
 
-        context = ssl.create_default_context(cafile=os.getenv('VAULT_CACERT'),
-                                             capath=os.getenv('VAULT_CAPATH'))
-
-        request_url = urljoin(url, "v1/%s" % (key))
         try:
+            context = ssl.create_default_context(cafile=os.getenv('VAULT_CACERT'),
+                                                 capath=os.getenv('VAULT_CAPATH'))
+            request_url = urljoin(url, "v1/%s" % (key))
             req = urllib2.Request(request_url, data)
             req.add_header('X-Vault-Token', token)
             req.add_header('Content-Type', 'application/json')
             response = urllib2.urlopen(req, context=context)
+        except AttributeError as e:
+            python_version_cur = ".".join([str(version_info.major),
+                                           str(version_info.minor),
+                                           str(version_info.micro)])
+            python_version_min = "2.7.9"
+            if StrictVersion(python_version_cur) < StrictVersion(python_version_min):
+                raise AnsibleError('Unable to read %s from vault:'
+                                   ' Using Python %s and vault lookup plugin requires at least %s'
+                                   % (key, python_version_cur, python_version_min))
+            else:
+                raise AnsibleError('Unable to read %s from vault: %s' % (key, e))
         except urllib2.HTTPError as e:
             raise AnsibleError('Unable to read %s from vault: %s' % (key, e))
         except Exception as e:

--- a/vault.py
+++ b/vault.py
@@ -13,7 +13,9 @@ except ImportError:
     class LookupBase(object):
         def __init__(self, basedir=None, runner=None, **kwargs):
             self.runner = runner
-            self.basedir = self.runner.basedir
+            self.basedir = basedir or (self.runner.basedir
+                                       if self.runner
+                                       else None)
 
         def get_basedir(self, variables):
             return self.basedir

--- a/vault.py
+++ b/vault.py
@@ -65,14 +65,21 @@ class LookupModule(LookupBase):
         if not token:
             raise AnsibleError('VAULT_TOKEN environment variable is missing')
 
+        cafile = os.getenv('VAULT_CACERT')
+        capath = os.getenv('VAULT_CAPATH')
         try:
-            context = ssl.create_default_context(cafile=os.getenv('VAULT_CACERT'),
-                                                 capath=os.getenv('VAULT_CAPATH'))
+            if cafile or capath:
+                context = ssl.create_default_context(cafile=cafile, capath=capath)
+            else:
+                context = None
             request_url = urljoin(url, "v1/%s" % (key))
             req = urllib2.Request(request_url, data)
             req.add_header('X-Vault-Token', token)
             req.add_header('Content-Type', 'application/json')
-            response = urllib2.urlopen(req, context=context)
+            if context:
+                response = urllib2.urlopen(req, context=context)
+            else:
+                response = urllib2.urlopen(req)
         except AttributeError as e:
             python_version_cur = ".".join([str(version_info.major),
                                            str(version_info.minor),
@@ -80,7 +87,8 @@ class LookupModule(LookupBase):
             python_version_min = "2.7.9"
             if StrictVersion(python_version_cur) < StrictVersion(python_version_min):
                 raise AnsibleError('Unable to read %s from vault:'
-                                   ' Using Python %s and vault lookup plugin requires at least %s'
+                                   ' Using Python %s, and vault lookup plugin requires at least %s'
+                                   ' to use an SSL context (VAULT_CACERT or VAULT_CAPATH)'
                                    % (key, python_version_cur, python_version_min))
             else:
                 raise AnsibleError('Unable to read %s from vault: %s' % (key, e))

--- a/vault.py
+++ b/vault.py
@@ -61,9 +61,18 @@ class LookupModule(LookupBase):
         if not url:
             raise AnsibleError('VAULT_ADDR environment variable is missing')
 
+        # the environment variable takes precedence over the file-based token
         token = os.getenv('VAULT_TOKEN')
         if not token:
-            raise AnsibleError('VAULT_TOKEN environment variable is missing')
+            try:
+                with open(os.path.join(os.getenv('HOME'), '.vault-token')) as file:
+                    token = file.read()
+            except IOError:
+                # token not found in file is same case below as not found in env var
+                pass
+        if not token:
+            raise AnsibleError('Vault authentication token missing. Specify with'
+                               ' VAULT_TOKEN environment variable or $HOME/.vault-token')
 
         cafile = os.getenv('VAULT_CACERT')
         capath = os.getenv('VAULT_CAPATH')


### PR DESCRIPTION
I only really meant this pull request to be these changes:
* https://github.com/jhaals/ansible-vault/commit/be6b1a49bda3b7f555c43c90652956818848592a

But it is cummulatively showing both this, as well as my previous two (still outstanding) pull requests:
* https://github.com/jhaals/ansible-vault/pull/20
* https://github.com/jhaals/ansible-vault/pull/21

Apologies if I'm not handling this well. My familiarity with github is limited; I'm used to just using straight up git.

Anyway, the base for this idea is the main part of this previous rejected pull request:
* https://github.com/jhaals/ansible-vault/pull/16

I kept the part reading the token from the file if present and the env var is not set. I incorporated the suggestions about handling IOError, updating the error message, and ensuring the file is closed.

I explicitly did *not* set the SSL protocol version in the context options. First, I am not using homebrew, so I have no way of either duplicating whatever problem might exist, or testing a fix. Second, this page notes "Deprecated since version 2.7.13: OpenSSL has deprecated all version specific protocols. Use the default protocol with flags like OP_NO_SSLv3 instead."
* https://docs.python.org/2/library/ssl.html#ssl.PROTOCOL_TLSv1_2