### PR TITLE
Feature/set variables

### DIFF
--- a/vault.py
+++ b/vault.py
@@ -2,6 +2,8 @@ import os
 import urllib2
 import json
 import ssl
+from distutils.version import StrictVersion
+from sys import version_info
 from urlparse import urljoin
 
 from ansible.errors import AnsibleError
@@ -63,15 +65,25 @@ class LookupModule(LookupBase):
         if not token:
             raise AnsibleError('VAULT_TOKEN environment variable is missing')
 
-        context = ssl.create_default_context(cafile=os.getenv('VAULT_CACERT'),
-                                             capath=os.getenv('VAULT_CAPATH'))
-
-        request_url = urljoin(url, "v1/%s" % (key))
         try:
+            context = ssl.create_default_context(cafile=os.getenv('VAULT_CACERT'),
+                                                 capath=os.getenv('VAULT_CAPATH'))
+            request_url = urljoin(url, "v1/%s" % (key))
             req = urllib2.Request(request_url, data)
             req.add_header('X-Vault-Token', token)
             req.add_header('Content-Type', 'application/json')
             response = urllib2.urlopen(req, context=context)
+        except AttributeError as e:
+            python_version_cur = ".".join([str(version_info.major),
+                                           str(version_info.minor),
+                                           str(version_info.micro)])
+            python_version_min = "2.7.9"
+            if StrictVersion(python_version_cur) < StrictVersion(python_version_min):
+                raise AnsibleError('Unable to read %s from vault:'
+                                   ' Using Python %s and vault lookup plugin requires at least %s'
+                                   % (key, python_version_cur, python_version_min))
+            else:
+                raise AnsibleError('Unable to read %s from vault: %s' % (key, e))
         except urllib2.HTTPError as e:
             raise AnsibleError('Unable to read %s from vault: %s' % (key, e))
         except Exception as e:

--- a/vault.py
+++ b/vault.py
@@ -13,7 +13,9 @@ except ImportError:
     class LookupBase(object):
         def __init__(self, basedir=None, runner=None, **kwargs):
             self.runner = runner
-            self.basedir = self.runner.basedir
+            self.basedir = basedir or (self.runner.basedir
+                                       if self.runner
+                                       else None)
 
         def get_basedir(self, variables):
             return self.basedir

--- a/vault.py
+++ b/vault.py
@@ -65,14 +65,21 @@ class LookupModule(LookupBase):
         if not token:
             raise AnsibleError('VAULT_TOKEN environment variable is missing')
 
+        cafile = os.getenv('VAULT_CACERT')
+        capath = os.getenv('VAULT_CAPATH')
         try:
-            context = ssl.create_default_context(cafile=os.getenv('VAULT_CACERT'),
-                                                 capath=os.getenv('VAULT_CAPATH'))
+            if cafile or capath:
+                context = ssl.create_default_context(cafile=cafile, capath=capath)
+            else:
+                context = None
             request_url = urljoin(url, "v1/%s" % (key))
             req = urllib2.Request(request_url, data)
             req.add_header('X-Vault-Token', token)
             req.add_header('Content-Type', 'application/json')
-            response = urllib2.urlopen(req, context=context)
+            if context:
+                response = urllib2.urlopen(req, context=context)
+            else:
+                response = urllib2.urlopen(req)
         except AttributeError as e:
             python_version_cur = ".".join([str(version_info.major),
                                            str(version_info.minor),
@@ -80,7 +87,8 @@ class LookupModule(LookupBase):
             python_version_min = "2.7.9"
             if StrictVersion(python_version_cur) < StrictVersion(python_version_min):
                 raise AnsibleError('Unable to read %s from vault:'
-                                   ' Using Python %s and vault lookup plugin requires at least %s'
+                                   ' Using Python %s, and vault lookup plugin requires at least %s'
+                                   ' to use an SSL context (VAULT_CACERT or VAULT_CAPATH)'
                                    % (key, python_version_cur, python_version_min))
             else:
                 raise AnsibleError('Unable to read %s from vault: %s' % (key, e))

--- a/vault.py
+++ b/vault.py
@@ -59,7 +59,7 @@ class LookupModule(LookupBase):
 
         # the environment variable takes precendence over the Ansible variable.
         url = os.getenv('VAULT_ADDR')
-        if not url and 'vault_addr' in inject:
+        if not url and inject and 'vault_addr' in inject:
             url = inject['vault_addr']            
         if not url:
             raise AnsibleError('Vault address not set. Specify with'
@@ -83,9 +83,9 @@ class LookupModule(LookupBase):
         # environment variables take precendence over Ansible variables.
         cafile = os.getenv('VAULT_CACERT')
         capath = os.getenv('VAULT_CAPATH')
-        if not cafile and 'vault_cacert' in inject:
+        if not cafile and inject and 'vault_cacert' in inject:
             cafile = inject['vault_cacert']            
-        if not capath and 'vault_capath' in inject:
+        if not capath and inject and 'vault_capath' in inject:
             capath = inject['vault_capath']            
         try:
             if cafile or capath:

--- a/vault.py
+++ b/vault.py
@@ -57,11 +57,17 @@ class LookupModule(LookupBase):
         except:
             field = None
 
+        # the environment variable takes precendence over the Ansible variable.
         url = os.getenv('VAULT_ADDR')
+        if not url and 'vault_addr' in inject:
+            url = inject['vault_addr']            
         if not url:
-            raise AnsibleError('VAULT_ADDR environment variable is missing')
+            raise AnsibleError('Vault address not set. Specify with'
+                               ' VAULT_ADDR environment variable or vault_addr Ansible variable')
 
-        # the environment variable takes precedence over the file-based token
+        # the environment variable takes precedence over the file-based token.
+        # intentionally do *not* support setting this via an Ansible variable,
+        # so as not to encourage bad security practices.
         token = os.getenv('VAULT_TOKEN')
         if not token:
             try:
@@ -74,8 +80,13 @@ class LookupModule(LookupBase):
             raise AnsibleError('Vault authentication token missing. Specify with'
                                ' VAULT_TOKEN environment variable or $HOME/.vault-token')
 
+        # environment variables take precendence over Ansible variables.
         cafile = os.getenv('VAULT_CACERT')
         capath = os.getenv('VAULT_CAPATH')
+        if not cafile and 'vault_cacert' in inject:
+            cafile = inject['vault_cacert']            
+        if not capath and 'vault_capath' in inject:
+            capath = inject['vault_capath']            
         try:
             if cafile or capath:
                 context = ssl.create_default_context(cafile=cafile, capath=capath)

--- a/vault.py
+++ b/vault.py
@@ -61,9 +61,18 @@ class LookupModule(LookupBase):
         if not url:
             raise AnsibleError('VAULT_ADDR environment variable is missing')
 
+        # the environment variable takes precedence over the file-based token
         token = os.getenv('VAULT_TOKEN')
         if not token:
-            raise AnsibleError('VAULT_TOKEN environment variable is missing')
+            try:
+                with open(os.path.join(os.getenv('HOME'), '.vault-token')) as file:
+                    token = file.read()
+            except IOError:
+                # token not found in file is same case below as not found in env var
+                pass
+        if not token:
+            raise AnsibleError('Vault authentication token missing. Specify with'
+                               ' VAULT_TOKEN environment variable or $HOME/.vault-token')
 
         cafile = os.getenv('VAULT_CACERT')
         capath = os.getenv('VAULT_CAPATH')

--- a/vault.py
+++ b/vault.py
@@ -58,9 +58,8 @@ class LookupModule(LookupBase):
             field = None
 
         # the environment variable takes precendence over the Ansible variable.
-        url = os.getenv('VAULT_ADDR')
-        if not url and inject and 'vault_addr' in inject:
-            url = inject['vault_addr']            
+        # Ansible variables are passed via "variables" in ansible 2.x, "inject" in 1.9.x
+        url = os.getenv('VAULT_ADDR') or (variables or inject).get('vault_addr')
         if not url:
             raise AnsibleError('Vault address not set. Specify with'
                                ' VAULT_ADDR environment variable or vault_addr Ansible variable')
@@ -80,13 +79,8 @@ class LookupModule(LookupBase):
             raise AnsibleError('Vault authentication token missing. Specify with'
                                ' VAULT_TOKEN environment variable or $HOME/.vault-token')
 
-        # environment variables take precendence over Ansible variables.
-        cafile = os.getenv('VAULT_CACERT')
-        capath = os.getenv('VAULT_CAPATH')
-        if not cafile and inject and 'vault_cacert' in inject:
-            cafile = inject['vault_cacert']            
-        if not capath and inject and 'vault_capath' in inject:
-            capath = inject['vault_capath']            
+        cafile = os.getenv('VAULT_CACERT') or (variables or inject).get('vault_cacert')
+        capath = os.getenv('VAULT_CAPATH') or (variables or inject).get('vault_capath')
         try:
             if cafile or capath:
                 context = ssl.create_default_context(cafile=cafile, capath=capath)


### PR DESCRIPTION
Once again, the diffs being shown are cumulative, and also including my other outstanding pull requests:
* #20 
* #21 
* #22 

Again, apologies if there is a better way to be handling this. If you just want to see the commits for this issue, it's the 3 most recent ones, on 07 Nov 2016:

```
$ git diff HEAD^^^ HEAD
diff --git a/vault.py b/vault.py
index 753df27..707f73e 100644
--- a/vault.py
+++ b/vault.py
@@ -57,11 +57,16 @@ class LookupModule(LookupBase):
         except:
             field = None
 
-        url = os.getenv('VAULT_ADDR')
+        # the environment variable takes precendence over the Ansible variable.
+        # Ansible variables are passed via "variables" in ansible 2.x, "inject" in 1.9.x
+        url = os.getenv('VAULT_ADDR') or (variables or inject).get('vault_addr')
         if not url:
-            raise AnsibleError('VAULT_ADDR environment variable is missing')
+            raise AnsibleError('Vault address not set. Specify with'
+                               ' VAULT_ADDR environment variable or vault_addr Ansible variable')
 
-        # the environment variable takes precedence over the file-based token
+        # the environment variable takes precedence over the file-based token.
+        # intentionally do *not* support setting this via an Ansible variable,
+        # so as not to encourage bad security practices.
         token = os.getenv('VAULT_TOKEN')
         if not token:
             try:
@@ -74,8 +79,8 @@ class LookupModule(LookupBase):
             raise AnsibleError('Vault authentication token missing. Specify with'
                                ' VAULT_TOKEN environment variable or $HOME/.vault-token')
 
-        cafile = os.getenv('VAULT_CACERT')
-        capath = os.getenv('VAULT_CAPATH')
+        cafile = os.getenv('VAULT_CACERT') or (variables or inject).get('vault_cacert')
+        capath = os.getenv('VAULT_CAPATH') or (variables or inject).get('vault_capath')
         try:
             if cafile or capath:
                 context = ssl.create_default_context(cafile=cafile, capath=capath)
rich@rich-trusty [15:20:02 Mon Nov 07] ~/git/github.com/locationlabs/ansible-vault
```