### PR TITLE
don't create an SSL context if not needed

### DIFF
--- a/vault.py
+++ b/vault.py
@@ -84,10 +84,7 @@ class LookupModule(LookupBase):
             req = urllib2.Request(request_url, data)
             req.add_header('X-Vault-Token', token)
             req.add_header('Content-Type', 'application/json')
-            if context:
-                response = urllib2.urlopen(req, context=context)
-            else:
-                response = urllib2.urlopen(req)
+            response = urllib2.urlopen(req, context=context) if context else urllib2.urlopen(req)
         except AttributeError as e:
             python_version_cur = ".".join([str(version_info.major),
                                            str(version_info.minor),

--- a/vault.py
+++ b/vault.py
@@ -77,10 +77,9 @@ class LookupModule(LookupBase):
         cafile = os.getenv('VAULT_CACERT')
         capath = os.getenv('VAULT_CAPATH')
         try:
+            context = None
             if cafile or capath:
                 context = ssl.create_default_context(cafile=cafile, capath=capath)
-            else:
-                context = None
             request_url = urljoin(url, "v1/%s" % (key))
             req = urllib2.Request(request_url, data)
             req.add_header('X-Vault-Token', token)


### PR DESCRIPTION
Specifically, don't create one (and don't use it) if neither
VAULT_CACERT or VAULT_CAPATH are defined.

This narrows the Python >= 2.7.9 requirement. Now earlier versions work
if there is no SSL context, because we're not calling
ssl.create_default_context(), and we're not passing a context attribute
to urllib2.urlopen(), which is also new as of 2.7.9:
https://docs.python.org/2/library/urllib2.html#urllib2.urlopen