### PR TITLE
Feature/set variables try2

### DIFF
--- a/vault.py
+++ b/vault.py
@@ -57,11 +57,17 @@ class LookupModule(LookupBase):
         except:
             field = None
 
+        # the environment variable takes precendence over the Ansible variable.
         url = os.getenv('VAULT_ADDR')
+        if not url and 'vault_addr' in inject:
+            url = inject['vault_addr']            
         if not url:
-            raise AnsibleError('VAULT_ADDR environment variable is missing')
+            raise AnsibleError('Vault address not set. Specify with'
+                               ' VAULT_ADDR environment variable or vault_addr Ansible variable')
 
-        # the environment variable takes precedence over the file-based token
+        # the environment variable takes precedence over the file-based token.
+        # intentionally do *not* support setting this via an Ansible variable,
+        # so as not to encourage bad security practices.
         token = os.getenv('VAULT_TOKEN')
         if not token:
             try:
@@ -74,8 +80,13 @@ class LookupModule(LookupBase):
             raise AnsibleError('Vault authentication token missing. Specify with'
                                ' VAULT_TOKEN environment variable or $HOME/.vault-token')
 
+        # environment variables take precendence over Ansible variables.
         cafile = os.getenv('VAULT_CACERT')
         capath = os.getenv('VAULT_CAPATH')
+        if not cafile and 'vault_cacert' in inject:
+            cafile = inject['vault_cacert']            
+        if not capath and 'vault_capath' in inject:
+            capath = inject['vault_capath']            
         try:
             context = None
             if cafile or capath:

--- a/vault.py
+++ b/vault.py
@@ -58,9 +58,8 @@ class LookupModule(LookupBase):
             field = None
 
         # the environment variable takes precendence over the Ansible variable.
-        url = os.getenv('VAULT_ADDR')
-        if not url and inject and 'vault_addr' in inject:
-            url = inject['vault_addr']            
+        # Ansible variables are passed via "variables" in ansible 2.x, "inject" in 1.9.x
+        url = os.getenv('VAULT_ADDR') or (variables or inject).get('vault_addr')
         if not url:
             raise AnsibleError('Vault address not set. Specify with'
                                ' VAULT_ADDR environment variable or vault_addr Ansible variable')
@@ -80,13 +79,8 @@ class LookupModule(LookupBase):
             raise AnsibleError('Vault authentication token missing. Specify with'
                                ' VAULT_TOKEN environment variable or $HOME/.vault-token')
 
-        # environment variables take precendence over Ansible variables.
-        cafile = os.getenv('VAULT_CACERT')
-        capath = os.getenv('VAULT_CAPATH')
-        if not cafile and inject and 'vault_cacert' in inject:
-            cafile = inject['vault_cacert']            
-        if not capath and inject and 'vault_capath' in inject:
-            capath = inject['vault_capath']            
+        cafile = os.getenv('VAULT_CACERT') or (variables or inject).get('vault_cacert')
+        capath = os.getenv('VAULT_CAPATH') or (variables or inject).get('vault_capath')
         try:
             context = None
             if cafile or capath:

--- a/vault.py
+++ b/vault.py
@@ -59,7 +59,7 @@ class LookupModule(LookupBase):
 
         # the environment variable takes precendence over the Ansible variable.
         url = os.getenv('VAULT_ADDR')
-        if not url and 'vault_addr' in inject:
+        if not url and inject and 'vault_addr' in inject:
             url = inject['vault_addr']            
         if not url:
             raise AnsibleError('Vault address not set. Specify with'
@@ -83,9 +83,9 @@ class LookupModule(LookupBase):
         # environment variables take precendence over Ansible variables.
         cafile = os.getenv('VAULT_CACERT')
         capath = os.getenv('VAULT_CAPATH')
-        if not cafile and 'vault_cacert' in inject:
+        if not cafile and inject and 'vault_cacert' in inject:
             cafile = inject['vault_cacert']            
-        if not capath and 'vault_capath' in inject:
+        if not capath and inject and 'vault_capath' in inject:
             capath = inject['vault_capath']            
         try:
             context = None


### PR DESCRIPTION
This is a replacement for #23 

The idea is that vault_addr, vault_cacert, and vault_capath can be set as Ansible variables, as an alternative to using the corresponding environment variables. If both are set, the environment variable takes precedence.

Note that vault_token is explicitly left out of this. Setting this to a fixed value checked into revision control and available for all to see would be a bad security practice. (Note that #25 already provides an alternative to the environment variable for that.)