### PR TITLE
Better troubleshooting information when opening $HOME/.vault-token

### DIFF
--- a/vault.py
+++ b/vault.py
@@ -1,6 +1,7 @@
 import os
 import urllib2
 import json
+import errno
 import ssl
 from distutils.version import StrictVersion
 from sys import version_info
@@ -72,15 +73,18 @@ class LookupModule(LookupBase):
         # so as not to encourage bad security practices.
         token = os.getenv('VAULT_TOKEN')
         if not token:
+            token_path = os.path.join(os.getenv('HOME'), '.vault-token')
             try:
-                with open(os.path.join(os.getenv('HOME'), '.vault-token')) as file:
-                    token = file.read().strip()
-            except IOError:
-                # token not found in file is same case below as not found in env var
-                pass
+                with open(token_path) as token_file:
+                    token = token_file.read().strip()
+            except IOError as err:
+                if err.errno == errno.ENOENT:
+                    pass
+                raise AnsibleError('Error occurred when opening ' + token_path + ': ' + err.strerror)
         if not token:
             raise AnsibleError('Vault authentication token missing. Specify with'
-                               ' VAULT_TOKEN environment variable or $HOME/.vault-token')
+                               ' VAULT_TOKEN environment variable or in $HOME/.vault-token '
+                               '(Current $HOME value is ' + os.getenv('HOME') + ')')
 
         cafile = os.getenv('VAULT_CACERT') or (variables or inject).get('vault_cacert')
         capath = os.getenv('VAULT_CAPATH') or (variables or inject).get('vault_capath')

--- a/vault.py
+++ b/vault.py
@@ -78,9 +78,8 @@ class LookupModule(LookupBase):
                 with open(token_path) as token_file:
                     token = token_file.read().strip()
             except IOError as err:
-                if err.errno == errno.ENOENT:
-                    pass
-                raise AnsibleError('Error occurred when opening ' + token_path + ': ' + err.strerror)
+                if err.errno != errno.ENOENT:
+                    raise AnsibleError('Error occurred when opening ' + token_path + ': ' + err.strerror)
         if not token:
             raise AnsibleError('Vault authentication token missing. Specify with'
                                ' VAULT_TOKEN environment variable or in $HOME/.vault-token '


### PR DESCRIPTION
Currently, when running in an environment like Ansible Tower, it may be hard to understand the root cause of problems. Tower runs playbooks in a bubblewrap by default, which makes for some non-obvious problems when a file that definitely exists somewhy cannot be found. Also, right now any permission problems would be reported as a missing file. 

This change adds more granular logging around searching for the token in `$HOME/.vault-token` file.