### PR TITLE
Support quoted params & only split params on first '='.

### DIFF
--- a/vault.py
+++ b/vault.py
@@ -8,6 +8,7 @@ except ImportError:
 import json
 import errno
 import ssl
+import shlex
 from distutils.version import StrictVersion
 from sys import version_info
 
@@ -78,11 +79,11 @@ class LookupModule(LookupBase):
 
         try:
             parameters = term_split[1]
-            parameters = parameters.split(' ')
+            parameters = shlex.split(parameters)
 
             parameter_bag = {}
             for parameter in parameters:
-                parameter_split = parameter.split('=')
+                parameter_split = parameter.split('=', 1)
 
                 parameter_key = parameter_split[0]
                 parameter_value = parameter_split[1]


### PR DESCRIPTION
This allows users to submit values with whitespace. Fixes #48.

Noticed while I was making this that param values with `=` chars would silently lose everything after that character, so I added it in as well.

Used the following playbook as a test case - not too familiar with ansible plugin development, please advise if there's a better method.

```
---
- hosts: localhost

  tasks:
    # This task writes the value fine, but must ignore_errors since nothing is returned
    - name: Create test value
      debug:
        msg: "{{ lookup('vault', 'secret/dev/vaulttest hello=world whitespace=\"one two\tthree\nfour\rfive\r\nsix\" equals=two+two=four') }}"
      ignore_errors: yes

    - name: Read test value into dict
      set_fact:
        my_result: "{{ lookup('vault', 'secret/dev/vaulttest') }}"

    - name: Show it
      debug:
        var: my_result
```