### PR TITLE
fix bug in _fetch_client_token

### DIFF
--- a/vault.py
+++ b/vault.py
@@ -169,7 +169,10 @@ class LookupModule(LookupBase):
                 context.check_hostname = cahostverify
             elif skipverify:
                 context = ssl._create_unverified_context()
-            data = data.encode('utf-8') if data else None
+
+            for key, value in data.items():
+                data[key] = value.encode('utf-8')
+
             req = urllib2.Request(url, json.dumps(data))
             req.add_header('Content-Type', 'application/json')
             response = urllib2.urlopen(req, context=context) if context else urllib2.urlopen(req)


### PR DESCRIPTION
This fixes a bug that only occurs when ~/.vault-token is not present (i.e. Vault does not have a valid token).

From what I can tell, the `data` parameter this method takes is always a dict, so I `.encode('utf-8')` every value in the dict that this method is passed. This change naively assumes `data` will never be nested, which should be fine for now, but may need to be changed in the future.

The error message I was getting on `master` is below:
`
fatal: [10.10.19.108]: FAILED! => {"changed": false, "failed": true, "msg": "AnsibleError: An unhandled exception occurred while running the lookup plugin 'vault'. Error was a <class 'ansible.errors.AnsibleError'>, original message: Unable to retrieve personal token from vault: 'dict' object has no attribute 'encode'"}`